### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the job of these reducers to return to us a new state.
 ## Instructions
 
 1. In `managePresents.js`, write a function called `managePresents()` that takes
-   in the previous state and an action as its argument. Set an default value for
+   in the previous state and an action as its argument. Set a default value for
    the state argument - an object with a key, `numberOfPresents`, assigned to
    `0`.
 


### PR DESCRIPTION
corrected grammar error for README.md.  Under instruction #1 it read "Set an default value" changed it to "Set a default value".